### PR TITLE
Fix & allow multi sector file reads

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,18 +1,18 @@
 # mpyq.js
 
-mpyq.js is a port of the [mpyq Python library](https://github.com/eagleflo/mpyq) for reading MPQ archives used in many of Blizzard's games.
+This is a fork of [mpyq.js](https://github.com/Farof/mpyqjs), which is a port of the [mpyq Python library](https://github.com/eagleflo/mpyq) for reading MPQ archives used in many of Blizzard's games. This fork fixes a major bug related to opening multipart archives. 
 
 It is a straightforward port with the same functionnalities and limitations. See the [original Readme](https://github.com/eagleflo/mpyq) for details.
 
 ## Installation
 
-    npm install -S mpyqjs
+    npm install -S empeeku
 
 ## Usage
 
 ### As a library
 
-    const mpq = require('mpyq');
+    const mpq = require('empeeku');
     const MPQArchive = mpq.MPQArchive;
 
 ### From the command line
@@ -39,7 +39,9 @@ While this port has been successfully used to perform the operations provided an
 
 ## License
 
-ISC License (ISC) - Copyright (c) 2016, Mathieu Merdy
+empeeku ISC License (ISC) - Copyright (c) 2017, Andy Baird
+
+mpyq.js ISC License (ISC) - Copyright (c) 2016, Mathieu Merdy
 
 ---
 

--- a/mpyq.js
+++ b/mpyq.js
@@ -196,7 +196,6 @@ MPQArchive.prototype.readFile = function(filename, forceDecompress) {
     if (!(blockEntry.flags & MPQ_FILE_SINGLE_UNIT)) {
       // File consists of many sectors. They all need to be
       // decompressed separately and united.
-      throw new Error('Not yet implemented');
 
       var sectorSize = 512 << this.header.sectorSizeShift;
       var sectors = Math.trunc(blockEntry.size / sectorSize) + 1;

--- a/mpyq.js
+++ b/mpyq.js
@@ -210,8 +210,8 @@ MPQArchive.prototype.readFile = function(filename, forceDecompress) {
       }
 
       var positions = [], i;
-      for (i = 0; i < (sectors + i); i += 1) {
-        positions[i] = fileData.readUInt32LE(i * 4);
+      for (i = 0; i < (sectors + 1); i += 1) {
+        positions[i] = fileData.readUInt32LE(4*i);
       }
       
       var ln = positions.length - (crc ? 2 : 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "empeeku",
   "version": "1.0.2",
+  "main": "mpyq.js",
   "keywords": [
     "mpq",
     "blizzard",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,21 @@
 {
-  "name": "mpyqjs",
-  "version": "1.0.1",
+  "name": "empeeku",
+  "version": "1.0.2",
   "keywords": [
     "mpq",
     "blizzard",
-    "archive"
+    "archive",
+    "starcraft",
+    "warcraft"
   ],
   "description": "Javascript port of mpyq python library for reading MPQ archives.",
-  "author": "Farof",
+  "author": "ajbdev",
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Farof/mpyqjs.git"
+    "url": "https://github.com/nexus-devtools/empeekujs.git"
   },
-  "homepage": "https://github.com/Farof/mpyqjs",
+  "homepage": "https://github.com/nexus-devtools/empeekujs",
   "dependencies": {
     "long": "^3.0.3",
     "seek-bzip": "^1.0.5",


### PR DESCRIPTION
I fixed the bug in the multi sector file routine section that was causing the index out of range error. I have tested this using recent versions of StormReplay MPQ archives that sometimes store `replay.game.events` as multisector. I can upload my tests if you'd like (I didn't want to add a 300k MPQ archive to the repo).